### PR TITLE
feat: add offline notice for messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,17 +13,18 @@
   <button id="btn">send</button>
 
 
-  <script src="/socket.io/socket.io.js"></script>
+  <script src="D:\AlphaCampProjects\simple-socket-practice\node_modules\socket.io\client-dist\socket.io.js"></script>
   <script>
     const socket = io.connect('http://localhost:3000/', {
+      transports: ['websocket'],
       query: {
         auth:
-          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjI2NTM0NjcwfQ.5QnVDSQNwg8LFYDjlb8ECf9oFa0prn8j-VqtzaCDw2g'
-      },
+          'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjI2NjI3MTY4fQ.MC6qSnv8ukSj00UwMYRCn1Ba6OmsgKkbeqtcZ3ck8E0'
+      }
     })
     console.log(socket)
     let RoomId
-    socket.emit('join_private_room', ({ User1Id:1 , User2Id: 1 }), (data) => {
+    socket.emit('join_private_room', ({ User1Id: 1, User2Id: 1 }), (data) => {
       RoomId = data.roomId
       console.log(roomId)
     })
@@ -34,6 +35,7 @@
       console.log(value)
       socket.emit('post_private_msg', ({ UserId: 1, RoomId, content: value }))
     })
+    socket.on('notice_when_offline', (data) => { return console.log(data) })
     socket.on('get_private_msg', (data) => {
       console.log('回傳data', data)
     })

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -50,9 +50,9 @@ module.exports = {
           }
           socket.decoded = decoded
           const options = {
-            attributes: ['id', 'name', 'account', 'avatar']
-          }
-          let user = await User.findByPk(decoded.id, options)
+            attributes: ['id', 'name', 'account', 'avatar', 'lastOnlineAt']
+          };
+          let user = await User.findById(decoded.id, options);
           // console.log(user)
           user = user.toJSON()
           user.socketId = socket.id

--- a/migrations/20210718135028-add-lastOnlineAt-to-user.js
+++ b/migrations/20210718135028-add-lastOnlineAt-to-user.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Users', 'lastOnlineAt', {
+      type: Sequelize.DATE
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Users', 'lastOnlineAt')
+  }
+};

--- a/models/room.js
+++ b/models/room.js
@@ -18,9 +18,10 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.DATE,
     }
   }, {});
-  Room.associate = function(models) {
+  Room.associate = function (models) {
     Room.belongsTo(models.User, { foreignKey: "User1Id", as: "User1" })
     Room.belongsTo(models.User, { foreignKey: "User2Id", as: "User2" })
+    Room.hasMany(models.Message, { foreignKey: "RoomId", as: "Messages" })
   };
   return Room;
 };


### PR DESCRIPTION
- 在User table新增 `lastOnlineAt` 欄位，
⭐所以必須執行 `npx sequelize db:migrate` 對資料庫做migration
- 在 socket `disconnect`事件，加入 `lastOnlineAt` 欄位更新
- 新增 `notice_when_offline` 事件，讓前端收到上次上線至今所有有新訊息的聊天室。