### PR TITLE
Remove service data

### DIFF
--- a/controllers/socket/socketController.js
+++ b/controllers/socket/socketController.js
@@ -31,9 +31,12 @@ let socketController = {
     /* -------- logs -------- */
     await socketService.showAllSocketDetails(io)
     /* -------- emits -------- */
-    io.emit('user_leave', {
-      name: socket.data.user.name
-    })
+    const userRooms = await socketService.getUserRooms(socket.data.user.id, io)
+    if (!userRooms.has('PublicRoom')) {
+      io.emit('user_leave', {
+        name: socket.data.user.name
+      })
+    }
     const users = await socketService.getPublicRoomUsers(io)
     io.emit('online_users', {
       users

--- a/controllers/socket/socketController.js
+++ b/controllers/socket/socketController.js
@@ -7,15 +7,18 @@ const detail = chalk.keyword('yellowgreen')
 let socketController = {
   /* ---------------- PUBLIC ROOM ---------------- */
   joinPublicRoom: async (socket, io) => {
+    const userRooms = await socketService.getUserRooms(socket.data.user.id, io)
     /* -------- renew data -------- */
     await socket.join('PublicRoom')
     /* -------- logs -------- */
     socketService.showJoinPublicRoomNotice(socket)
     await socketService.showAllSocketDetails(io)
     /* -------- emits -------- */
-    io.emit('new_join', {
-      name: socket.data.user.name
-    })
+    if (!userRooms.has('PublicRoom')) {
+      io.emit('new_join', {
+        name: socket.data.user.name
+      })
+    }
     const users = await socketService.getPublicRoomUsers(io)
     io.emit('online_users', {
       users
@@ -137,7 +140,7 @@ let socketController = {
       if (receiverRooms.has('PrivatePage')) {
         /* ---- Receiver is on private page ---- */
         /* find data */
-        await record.update({isSeen: true})
+        await record.update({ isSeen: true })
         const updateMsgNoticeDetails =
           await socketService.getRoomDetailsForReceiver(SenderId, ReceiverId)
         updateMsgNoticeDetails.lastMsg = {

--- a/controllers/socket/socketController.js
+++ b/controllers/socket/socketController.js
@@ -1,126 +1,45 @@
 const socketService = require('../../service/socketService')
 const chalk = require('chalk')
-const socket = require('../../socket/socket')
 const highlight = chalk.bgYellow.black
-const notice = chalk.bgBlue.white
-const detail = chalk.magentaBright
+const notice = chalk.keyword('lawngreen').underline
+const detail = chalk.keyword('yellowgreen')
 
 let socketController = {
-  postSocket: (socket) => {
-    socketService.addNewSocketUser(socket)
-    socketService.showNewUserOnline(socket.id)
-    socket.emit('message', `Your socket id is  ${socket.id}`)
-  },
-  deleteSocket: (socket, io) => {
-    if (socketService.getPrivateRoomUserInfo(socket.id)) {
-      socketService.removeUserFromPrivateRoom(socket.id)
-      socketService.showLeavePrivatePageNotice(socket.id)
-    }
-    if (socketService.checkSocketIdInPublicRoom(socket.id)) {
-      socketService.showLeavePublicRoomNotice(null, socket.id)
-      socketService.removeUserFromPublicRoom(socket.id)
-      const users = socketService.getPublicRoomUsers(socket.id)
-      io.emit('online_users', {
-        users
-      })
-    }
-    if (socketService.checkSocketExists(socket)) {
-      socketService.removeSocketFromList(socket)
-    }
-    socketService.showUserOffline(socket.id)
-  },
-  joinPublicRoom: async (userId, socket, io) => {
-    socketService.showJoinPublicRoomNotice(userId, socket.id)
-    socketService.addSocketIdToPublicRoom(socket.id)
-    const ids = await io.allSockets()
-    socketService.showAllSocketDetails(ids)
-    const user = socketService.getUserInfo(socket.id)
+  /* ---------------- PUBLIC PAGE ---------------- */
+  joinPublicRoom: async (socket, io) => {
+    /* -------- renew data -------- */
+    await io.in(socket.id).socketsLeave(Array.from(socket.rooms))
+    await socket.join(['PublicRoom', socket.id, 'User' + socket.data.user.id])
+    /* -------- logs -------- */
+    socketService.showJoinPublicRoomNotice(socket)
+    await socketService.showAllSocketDetails(io)
+    /* -------- emits -------- */
     io.emit('new_join', {
-      name: user.name
+      name: socket.data.user.name
     })
-    const users = socketService.getPublicRoomUsers(socket.id)
+    const users = await socketService.getPublicRoomUsers(io)
     io.emit('online_users', {
       users
     })
   },
-  joinPrivatePage: async function (userId, socket) {
-    console.log(notice(`join_private_page: ${userId}`))
-    console.log(notice(`join_private_page-socketId ${socket.id}`))
-    socketService.addUserInfoToPrivateRoomSockets(userId, socket.id)
-    await socketService.toggleSeenMsgRecord(userId)
-    //emit get_private_rooms
-    const rooms = await socketService.getPrivateRooms(userId)
-    socket.emit('get_private_rooms', rooms)
-    const getMsgNoticeDetails = await socketService.getMsgNoticeDetails(userId)
-    socket.emit('get_msg_notice_details', getMsgNoticeDetails)
-    console.log(notice(`get_msg_notice_details to ${userId}`))
-  },
-  joinPrivateRoom: async (User1Id, User2Id, socket, io) => {
-    console.log(notice(`join_private_room:`), { User1Id, User2Id })
-    /* if miss join_private_page */
-    if (!socketService.getPrivateRoomUserInfo(socket.id)) {
-      console.log(notice(`[補] join_private_page: ${User1Id}`))
-      console.log(notice(`join_private_page-socketId ${socket.id}`))
-      socketService.addUserInfoToPrivateRoomSockets(User1Id, socket.id)
-      socket.emit('get_msg_notice_details', getMsgNoticeDetails)
-      console.log(notice(`get_msg_notice_details to ${User1Id}`))
-    }
-    await socketService.toggleReadPrivateMsg(User1Id, User2Id)
-    const roomId = await socketService.getRoomId(User1Id, User2Id)
-    socketService.setPrivateRoomId(socket.id, roomId)
-    console.log(detail(`set ${socket.id} new roomId to ${roomId}`))
-
-    // 找到User2 的socketId
-    // check isOnline or not
-    const user2Sockets = socketService.getUserSocketIds(User2Id)
-    if (user2Sockets) {
-      //join User1 into room
-      socket.join(roomId)
-      //join User2 into room
-      console.log(detail(`user2的socket:`), user2Sockets)
-      socketService.addUserToRoom(user2Sockets, roomId)
-    }
-    const ids = await io.allSockets()
-    socketService.showAllSocketDetails(ids)
-    console.log(detail(`最後roomId結果: ${roomId} `))
-    return roomId
-  },
-  leavePublicRoom: (userId, socket, io) => {
-    socketService.showLeavePublicRoomNotice(userId, socket.id)
-    socketService.removeUserFromPublicRoom(socket.id)
-    const user = socketService.getUserInfo(socket.id)
+  leavePublicRoom: async (socket, io) => {
+    /* -------- renew data -------- */
+    await socket.leave('PublicRoom')
+    socketService.showLeavePublicRoomNotice(socket)
+    /* -------- logs -------- */
+    await socketService.showAllSocketDetails(io)
+    /* -------- emits -------- */
     io.emit('user_leave', {
-      name: user.name
+      name: socket.data.user.name
     })
-    const users = socketService.getPublicRoomUsers()
+    const users = await socketService.getPublicRoomUsers(io)
     io.emit('online_users', {
       users
     })
   },
-  leavePrivatePage: (socket) => {
-    //去除privateRoomUsers內要離開的使用者
-    if (socketService.getPrivateRoomUserInfo(socket.id)) {
-      console.log(
-        notice(`leave_private_page: `),
-        socketService.getPrivateRoomUserInfo(socket.id)
-      )
-      socketService.removeUserFromPrivateRoom(socket.id)
-    }
-  },
-  getPublicHistory: async (offset, limit) => {
-    socketService.showGetPublicHistoryNotice()
-    //roomId 1 is PublicRoom
+  postPublicMsg: async (content, socket) => {
     const publicRoomId = 1
-    return await socketService.getRoomHistory(offset, limit, publicRoomId)
-  },
-  getPrivateHistory: async (offset, limit, RoomId) => {
-    console.log(notice(`get_private_history:`), { offset, limit, RoomId })
-    const messages = await socketService.getRoomHistory(offset, limit, RoomId)
-    return messages
-  },
-  postPublicMsg: async (content, userId, socket) => {
-    const publicRoomId = 1
-    socketService.showPostPublicHistoryNotice(content, userId)
+    const userId = socket.data.user.id
     if (!content) {
       return
     }
@@ -129,35 +48,75 @@ let socketController = {
       publicRoomId,
       content
     )
-    const user = socketService.getUserInfo(socket.id)
     socket.broadcast.emit('get_public_msg', {
       content: message.content,
       createdAt: message.createdAt,
-      avatar: user.avatar
+      avatar: socket.data.user.avatar
     })
+    // /* -------- better option ??? -------- */
+    // io.to('PublicRoom').emit('get_public_msg', {
+    //   content: message.content,
+    //   createdAt: message.createdAt,
+    //   avatar: user.avatar
+    // })
   },
-  postPrivateMsg: async (SenderId, ReceiverId, RoomId, content, socket) => {
-    console.log(notice(`post_private_msg:`), {
-      SenderId,
-      ReceiverId,
-      RoomId,
-      content
-    })
+  /* ---------------- PRIVATE PAGE ---------------- */
+  joinPrivatePage: async function (socket, io, isAdded) {
+    /* -------- renew data -------- */
+    await socket.join('PrivatePage')
+    await socketService.toggleSeenMsgRecord(socket.data.user.id)
+    /* -------- logs -------- */
+    socketService.showJoinPrivatePageNotice(socket, isAdded)
+    await socketService.showAllSocketDetails(io)
+    /* -------- emits -------- */
+    // get_private_rooms
+    const rooms = await socketService.getPrivateRooms(socket.data.user.id)
+    socket.emit('get_private_rooms', rooms)
+    console.log(notice(`[EMIT] get_private_rooms → ${socket.data.user.id}`, detail('\n', JSON.stringify(rooms))))
+    // get_msg_notice_details
+    const getMsgNoticeDetails = await socketService.getMsgNoticeDetails(socket.data.user.id)
+    socket.emit('get_msg_notice_details', getMsgNoticeDetails)
+    console.log(notice(`[EMIT] get_msg_notice_details → ${socket.data.user.id}`, detail('\n', JSON.stringify(getMsgNoticeDetails))))
+  },
+  joinPrivateRoom: async function (User1Id, User2Id, socket, io) {
+    /* -------- check missing event -------- */
+    if (!socket.rooms.has('PrivatePage')) {
+      this.joinPrivatePage(socket, io, true)
+    }
+    /* -------- renew data -------- */
+    const roomId = await socketService.getRoomId(User1Id, User2Id)
+    await socketService.toggleReadPrivateMsg(User1Id, User2Id)
+    await io.in(socket.id).socketsLeave(Array.from(socket.rooms))
+    await socket.join([roomId, 'PrivatePage', socket.id, 'User' + socket.data.user.id])
+    await socketService.showAllSocketDetails(io)
+    console.log(detail(`最後roomId結果: ${roomId} `))
+    return roomId
+  },
+  leavePrivatePage: async (socket, io) => {
+    /* -------- renew data -------- */
+    await io.in(socket.id).socketsLeave(Array.from(socket.rooms).filter(roomID => Number.isInteger(roomID)))
+    await socket.leave('PrivatePage')
+    /* -------- logs -------- */
+    console.log(detail(`${socket.id}room result:\n`), Array.from(socket.rooms))
+  },
+  postPrivateMsg: async (SenderId, ReceiverId, RoomId, content, socket, io) => {
     if (!content) {
       return
     }
-    const user = socketService.getUserInfo(socket.id)
+    const user = socket.data.user
+    /* -------- save message -------- */
     const message = await socketService.addMessage(SenderId, RoomId, content)
-    const isUserOnline = socketService.getUserSocketIds(ReceiverId) //在線的所有socketID
-    const isReceiverOnPrivatePage =
-      socketService.checkReceiverOnPrivatePage(ReceiverId) //receiver在private page的各個房間
-    /* no update record */
-    /* Receiver is  in room */ //Receiver在聊天室裡
+    /* -------- send to Receiver -------- */
+    let receiverRooms = await socketService.getUserRooms(ReceiverId, io) // {Set}
+
+    /* ---- Receiver is in room ---- */
+    /* no update */
     if (
-      isReceiverOnPrivatePage &&
-      isReceiverOnPrivatePage.includes(message.RoomId)
+      receiverRooms.has('PrivatePage') &&
+      receiverRooms.has(message.RoomId)
     ) {
-      let createdAt = message.createdAt
+      /* emit */
+      const createdAt = message.createdAt
       const avatar = user.avatar
       socket.to(RoomId).emit('get_private_msg', {
         UserId: SenderId,
@@ -166,23 +125,30 @@ let socketController = {
         avatar,
         createdAt
       })
-      console.log(detail(`send message to ${ReceiverId}`))
+      /* logs */
+      console.log(detail(`Receiver ${ReceiverId} is in room`))
+      console.log(notice(`[EMIT] get_private_msg → Room ${RoomId}`))
       return
     }
-    /* update record */
+
+    /* ---- Receiver is not in room ---- */
+    /* get record */
     let record = await socketService.getMsgRecord(RoomId, SenderId)
     if (!record) {
       record = await socketService.createMsgRecord(RoomId, SenderId, ReceiverId)
     }
+    /* update record */
     const unreadNum = record.unreadNum + 1
     record.isSeen = false
     await record.increment({ unreadNum: 1 })
-    /* Receiver is online */
-    if (isUserOnline) {
-      /* Receiver is on private page  */
-      if (isReceiverOnPrivatePage) {
-        /* Receiver is not in room */
+    if (receiverRooms.size) {
+      /* ---- Receiver is online ---- */
+      console.log(detail(`Receiver ${ReceiverId} is online`))
+      if (receiverRooms.has('PrivatePage')) {
+        /* ---- Receiver is on private page ---- */
+        /* find data */
         record.isSeen = true
+        await record.save()
         const updateMsgNoticeDetails =
           await socketService.getRoomDetailsForReceiver(SenderId, ReceiverId)
         updateMsgNoticeDetails.lastMsg = {
@@ -191,60 +157,60 @@ let socketController = {
           createdAt: message.createdAt
         }
         updateMsgNoticeDetails.unreadNum = unreadNum
-        isUserOnline.forEach((socketid) => {
-          socket
-            .to(socketid)
-            .emit('update_msg_notice_details', updateMsgNoticeDetails)
-        })
-        console.log(notice(`update_msg_notice_details to ${ReceiverId}`))
+        /* emit */
+        io.to('User' + ReceiverId).emit('update_msg_notice_details', updateMsgNoticeDetails)
+        /* logs */
+        console.log(detail(`Receiver ${ReceiverId} is on private page but not in room`))
+        console.log(notice(`[EMIT] update_msg_notice_details →`), await io.in('User' + ReceiverId).allSockets())
+        return
       } else {
-        /* Receiver is not on private page  */
+        /* ---- Receiver is not on private page ---- */
+        await record.save()
+        /* find data */
         const getMsgNotice = await socketService.getMsgNotice(ReceiverId, null)
-        isUserOnline.forEach((socketid) => {
-          socket.to(socketid).emit('get_msg_notice', getMsgNotice)
-        })
-        console.log(notice(`get_msg_notice to ${ReceiverId}`))
+        /* emit */
+        io.to('User' + ReceiverId).emit('get_msg_notice', getMsgNotice)
+        /* logs */
+        console.log(detail(`Receiver ${ReceiverId} is not on private page`))
+        console.log(notice(`[EMIT] get_msg_notice →`), await io.in('User' + ReceiverId).allSockets())
+        return
       }
     }
+    /* save final data */
     await record.save()
   },
-  postTimeline: async (ReceiverId, type, PostId, socket) => {
+  /* ---------------- TIMELINE ---------------- */
+  postTimeline: async (ReceiverId, type, PostId, socket, io) => {
+    /* -------- create TimelineRecord -------- */
     const records = await socketService.createTimelineRecord(
       ReceiverId,
       PostId,
       type,
-      socket.request.user
+      socket.data.user.id
     )
-    const receivers = records.receiver
+    const receivers = records.receiverId // Array
     const record = records.record
-    //確認至少有1 User在線，為了預載 noticeDetail
-    let atLeastOneUserOnline = socketService.atLeastOneUserOnline(receivers)
-
+    console.log(notice(`[Create Timeline Record]\n`), record[0])
+    /* -------- at least one receiver online -------- */
+    let atLeastOneUserOnline = await socketService.atLeastOneUserOnline(receivers, io)
     if (atLeastOneUserOnline) {
-      let noticeDetail = await socketService.parseTimelineData(
-        record[0]
-      )
-      receivers.forEach(async (receiver,i) => {
-        const getUserSocketIds = socketService.getUserSocketIds(receiver)
-        if (getUserSocketIds) {
-          const isOnTimelinePage =
-            socketService.checkReceiverOnTimelinePage(getUserSocketIds)
-          if (isOnTimelinePage) {
+      const noticeDetail = await socketService.parseTimelineData(record[0])
+      receivers.forEach(async (receiver, i) => {
+        const getUserSocketIds = await io.in('User' + receiver).allSockets()
+        /* -------- receiver online -------- */
+        if (getUserSocketIds.size) {
+          const receiverRooms = await socketService.getUserRooms(receiver, io)
+          /* -------- receiver on Timeline Page -------- */
+          if (receiverRooms.has('TimelinePage')) {
             // 更新動態isSeen
-            socketService.updateTimelineSeenAt(receiver)
-            isOnTimelinePage.forEach((socketId) => {
-              socket
-                .to(socketId)
-                .emit('update_timeline_notice_detail', noticeDetail)
-            })
+            socketService.seenTimeline(receiver, null)
+            await io.to('User' + receiver).emit('update_timeline_notice_detail', noticeDetail)
+            console.log(notice(`[EMIT] update_timeline_notice_detail → Receiver ${receiver}`))
             return
           }
-          //on other page
-          getUserSocketIds.forEach((socketId) => {
-            socket
-              .to(socketId)
-              .emit('update_timeline_notice', socketService.sendTimeNotice())
-          })
+          /* -------- receiver not on Timeline Page -------- */
+          socket.to('User' + receiver).emit('update_timeline_notice', socketService.sendTimelineNotice())
+          console.log(notice(`[EMIT] update_timeline_notice → Receiver ${receiver}`))
         }
       })
     }

--- a/controllers/socket/socketController.js
+++ b/controllers/socket/socketController.js
@@ -68,10 +68,6 @@ let socketController = {
     socketService.showJoinPrivatePageNotice(socket, isAdded)
     await socketService.showAllSocketDetails(io)
     /* -------- emits -------- */
-    // get_private_rooms
-    const rooms = await socketService.getPrivateRooms(socket.data.user.id)
-    socket.emit('get_private_rooms', rooms)
-    console.log(notice(`[EMIT] get_private_rooms → ${socket.data.user.id}`, detail('\n', JSON.stringify(rooms))))
     // get_msg_notice_details
     const getMsgNoticeDetails = await socketService.getMsgNoticeDetails(socket.data.user.id)
     socket.emit('get_msg_notice_details', getMsgNoticeDetails)

--- a/controllers/socket/socketController.js
+++ b/controllers/socket/socketController.js
@@ -8,8 +8,7 @@ let socketController = {
   /* ---------------- PUBLIC PAGE ---------------- */
   joinPublicRoom: async (socket, io) => {
     /* -------- renew data -------- */
-    await io.in(socket.id).socketsLeave(Array.from(socket.rooms))
-    await socket.join(['PublicRoom', socket.id, 'User' + socket.data.user.id])
+    await socket.join('PublicRoom')
     /* -------- logs -------- */
     socketService.showJoinPublicRoomNotice(socket)
     await socketService.showAllSocketDetails(io)
@@ -86,8 +85,8 @@ let socketController = {
     /* -------- renew data -------- */
     const roomId = await socketService.getRoomId(User1Id, User2Id)
     await socketService.toggleReadPrivateMsg(User1Id, User2Id)
-    await io.in(socket.id).socketsLeave(Array.from(socket.rooms))
-    await socket.join([roomId, 'PrivatePage', socket.id, 'User' + socket.data.user.id])
+    await io.in(socket.id).socketsLeave(Array.from(socket.rooms).filter(roomID => Number.isInteger(roomID)))
+    await socket.join(roomId)
     await socketService.showAllSocketDetails(io)
     console.log(detail(`最後roomId結果: ${roomId} `))
     return roomId

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -53,10 +53,9 @@ module.exports = {
             attributes: ['id', 'name', 'account', 'avatar', 'timelineSeenAt']
           }
           let user = await User.findById(decoded.id, options)
-          // console.log(user)
           user = user.toJSON()
-          user.socketId = socket.id
-          socket.request.user = user
+          socket.data.user = user
+          socket.join('User' + user.id)
           return next()
         }
       )

--- a/service/socketService.js
+++ b/service/socketService.js
@@ -103,7 +103,7 @@ let socketService = {
     }
     return roomId
   },
-  getPrivateRooms: async (userId) => {
+  getPrivateRooms: async (userId, offset, limit) => {
     const roomOption = {
       where: {
         [Op.or]: [{ User1Id: userId }, { User2Id: userId }],
@@ -149,7 +149,8 @@ let socketService = {
           'DESC'
         ]
       ],
-      limit: 5
+      offset,
+      limit
     }
     const rooms = await Room.findAll(roomOption).then((rooms) => {
       rooms.forEach((room) => {

--- a/service/socketService.js
+++ b/service/socketService.js
@@ -467,12 +467,6 @@ let socketService = {
     console.log(detail('room result:'), Array.from(socket.rooms), '\n')
   },
   showLeavePublicRoomNotice: (socket) => {
-    if (userId) {
-      console.log(notice(`[Leave Public Room] userID: ${socket.data.user.idd}`))
-      console.log(detail(`socket ID: ${socket.id}`))
-      console.log(detail('room result:'), Array.from(socket.rooms), '\n')
-      return
-    }
     console.log(notice(`[Leave Public Room] userID|${socket.data.user.id}`))
     console.log(detail(`socket ID: ${socket.id}`))
     console.log(detail('room result:'), Array.from(socket.rooms), '\n')

--- a/service/socketService.js
+++ b/service/socketService.js
@@ -46,8 +46,8 @@ let socketService = {
   getPublicRoomUsers: async (io) => {
     const publicRoomUsers = Array.from(await io.in('PublicRoom').allSockets())
     let users = []
-    publicRoomUsers.forEach(async (socketID) => {
-      let data = await io.sockets.sockets.get(socketID).data.user
+    publicRoomUsers.forEach((socketID) => {
+      let data = io.sockets.sockets.get(socketID).data.user
       users.push(data)
     })
     let allId = users.map((item) => item.id)
@@ -56,7 +56,7 @@ let socketService = {
   },
   getUserSocketIds: async (UserId, io) => {
     const users = []
-    const socketUsers = await io.sockets.sockets
+    const socketUsers =  io.sockets.sockets
     socketUsers.forEach((socket, socketID) => {
       if (socket.data.user.id === UserId) {
         users.push(socketID)
@@ -475,10 +475,10 @@ let socketService = {
     const allIDs = Array.from(await io.allSockets())
     console.log(detail('all sockets [系統偵測]'), '\n', allIDs)
     const userData = {}
-    await allIDs.forEach(async (socketID) => userData[socketID] = await io.sockets.sockets.get(socketID).data.user)
+    allIDs.forEach( (socketID) => userData[socketID] =  io.sockets.sockets.get(socketID).data.user)
     console.log(detail('socket data'), '\n', userData)
     const userRoom = {}
-    await allIDs.forEach(async (socketID) => userRoom[socketID] = Array.from(await io.sockets.sockets.get(socketID).rooms))
+    allIDs.forEach(async (socketID) => userRoom[socketID] = Array.from( io.sockets.sockets.get(socketID).rooms))
     console.log(detail('socket rooms'), '\n', userRoom)
     console.log(detail('user timestamps for timeline:'), '\n', userTimelineSeenAt)
   },

--- a/service/socketService.js
+++ b/service/socketService.js
@@ -430,11 +430,8 @@ let socketService = {
     return record
   },
   seenTimeline: (userID, timestamp) => {
-    if (timestamp) {
-      userTimelineSeenAt[userID] = timestamp
-      return
-    }
-    userTimelineSeenAt[receiver] = new Date()
+    userTimelineSeenAt[userID] = timestamp
+    return
   },
   readTimeline: async (timelineId) => {
     return await TimelineRecord.update(

--- a/service/socketService.js
+++ b/service/socketService.js
@@ -1,8 +1,4 @@
-const sockets = [] // array of sockets  找到對應的socket物件
-const socketUsers = {} // key(socketid) to value(id)
-const userData = {} // key(userid) to value(name, account, avatar, timelineSeenAt)
-const publicRoomUsers = [] // array of userIds 公開聊天室的socketId
-const privateRoomUsers = {} // key(socketid) to value(id, currentRoom)
+const userTimelineSeenAt = {} // key(userid) to value(timelineSeenAt)
 const timelineUsers = {} // key(socketid) to value(id)
 const db = require('../models')
 const {
@@ -19,82 +15,67 @@ const {
 const sequelize = require('sequelize')
 const { Op } = require('sequelize')
 const chalk = require('chalk')
+const user = require('../models/user')
 const highlight = chalk.bgYellow.black
-const notice = chalk.bgBlue.white
-const detail = chalk.magentaBright
+const notice = chalk.keyword('coral').underline
+const detail = chalk.keyword('lightcoral')
 
 let socketService = {
-  addNewSocketUser: (socket) => {
-    const currentUser = socket.request.user
-    if (!userData[currentUser.id]) {
-      userData[currentUser.id] = {
-        name: currentUser.name,
-        account: currentUser.account,
-        avatar: currentUser.avatar,
-        timelineSeenAt: currentUser.timelineSeenAt
-      }
+  addNewSocketUserTimelineSeenAt: (socket) => {
+    const currentUser = socket.data.user
+    if (!userTimelineSeenAt[currentUser.id]) {
+      userTimelineSeenAt[currentUser.id] = currentUser.timelineSeenAt
     }
-    /* connect */
-    // 儲存socket物件
-    sockets.push(socket)
-    // 建立socketId 與使用者資訊的對照表
-    socketUsers[socket.id] = currentUser.id
   },
-  addSocketIdToPublicRoom: (socketId) => {
-    publicRoomUsers.push(socketId)
-  },
-  addUserInfoToPrivateRoomSockets: (userId, socketId) => {
-    const userInfo = {
-      id: userId,
-      currentRoom: null
+  deleteAndUpdateTimelineSeenAt: async function (socket, io) {
+    const userId = socket.data.user.id
+    /* find user's other sockets */
+    const users = await io.in('User' + userId).allSockets()
+    if (users.size > 1) {
+      return
     }
-    //加入privateRoomUsers
-    privateRoomUsers[socketId] = userInfo
-    return
+    console.log(notice(`[Delete And Update timelineSeenAt] UserID ${userId}`))
+    await User.update({ timelineSeenAt: userTimelineSeenAt[userId] }, { where: { id: userId } })
+    delete userTimelineSeenAt[userId]
+    await this.showAllSocketDetails(io)
   },
   addMessage: async (UserId, RoomId, content) => {
     const message = await Message.create({ UserId, RoomId, content })
     return message
   },
-  addUserToRoom: (userSocketIds, roomId) => {
-    userSocketIds.forEach((socketId) => {
-      const targetSocket = sockets.find((element) => element.id === socketId)
-      console.log(targetSocket.id)
-      targetSocket.join(roomId)
-    })
-  },
-  setPrivateRoomId: (socketId, roomId) => {
-    privateRoomUsers[socketId].currentRoom = roomId
-    return
-  },
-  getPublicRoomUsers: (socketId) => {
+  getPublicRoomUsers: async (io) => {
+    const publicRoomUsers = Array.from(await io.in('PublicRoom').allSockets())
     let users = []
-    publicRoomUsers.forEach((socketId) => {
-      if (socketUsers[socketId]) {
-        users.push(userData[socketUsers[socketId]])
-      }
+    publicRoomUsers.forEach(async (socketID) => {
+      let data = await io.sockets.sockets.get(socketID).data.user
+      users.push(data)
     })
-    let allId = users.map((item) => item.account)
-    users = users.filter((user, i, arr) => allId.indexOf(user.account) === i)
+    let allId = users.map((item) => item.id)
+    users = users.filter((user, i, arr) => allId.indexOf(user.id) === i)
     return users
   },
-  getUserInfo: (socketId) => {
-    return userData[socketUsers[socketId]]
-  },
-  getPrivateRoomUserInfo: (socketId) => {
-    return privateRoomUsers[socketId]
-  },
-  getUserSocketIds: (UserId) => {
+  getUserSocketIds: async (UserId, io) => {
     const users = []
-    for (socketId in socketUsers) {
-      if (socketUsers[socketId] === UserId) {
-        users.push(socketId)
+    const socketUsers = await io.sockets.sockets
+    socketUsers.forEach((socket, socketID) => {
+      if (socket.data.user.id === UserId) {
+        users.push(socketID)
       }
-    }
+    })
+    console.log(detail('socketUsers@getUserSocketIds'), users)
     if (users.length) {
       return users
     }
     return false
+  },
+  getUserRooms: async (UserId, io) => {
+    let Rooms = new Set()
+    const sockets = await io.in('User' + UserId).fetchSockets()
+    for (const socket of sockets) {
+      socket.rooms.forEach(room => Rooms.add(room))
+    }
+    console.log(notice('Get User Rooms:\n'), Rooms)
+    return Rooms
   },
   getRoomId: async (User1Id, User2Id) => {
     //for frontend test
@@ -227,7 +208,7 @@ let socketService = {
   },
   getMsgNotice: async (userId, socket) => {
     if (socket) {
-      userId = socketUsers[socket.id]
+      userId = socket.data.user.id
     }
     const { count } = await MessageRecord.findAndCountAll({
       where: {
@@ -296,8 +277,8 @@ let socketService = {
     })
   },
   getTimelineNotice: async (socket) => {
-    const userId = socketUsers[socket.id]
-    const timestamp = userData[userId].timelineSeenAt
+    const userId = socket.data.user.id
+    const timestamp = socket.data.user.timelineSeenAt
     const { count } = await TimelineRecord.findAndCountAll({
       where: {
         UserId: userId,
@@ -308,9 +289,9 @@ let socketService = {
     })
     return count
   },
-  getTimelineNoticeDetails: async function (offset, limit, socketId) {
-    const userId = socketUsers[socketId]
-    const timestamp = userData[userId].timelineSeenAt
+  getTimelineNoticeDetails: async function (offset, limit, socket) {
+    const userId = socket.data.user.id
+    const timestamp = socket.data.user.timelineSeenAt
     let SeenRecords = []
     const UnseenRecords = await TimelineRecord.findAll({
       offset,
@@ -346,15 +327,7 @@ let socketService = {
     return { Unseen, Seen }
   },
   parseTimelineData: async (record) => {
-    const {
-      id,
-      ReplyId,
-      LikeId,
-      FollowerId,
-      SubscribeTweetId,
-      isRead,
-      createdAt
-    } = record.dataValues
+    const { id, ReplyId, LikeId, FollowerId, SubscribeTweetId, isRead, createdAt } = record.dataValues
     const replyOptions = {
       include: [
         {
@@ -417,40 +390,6 @@ let socketService = {
       return { id, Subscribing, isRead }
     }
   },
-  checkSocketExists: (socket) => {
-    return sockets.includes(socket)
-  },
-  checkSocketIdInPublicRoom: (socketId) => {
-    return publicRoomUsers.includes(socketId)
-  },
-  checkReceiverOnPrivatePage: (ReceiverId) => {
-    const receiverRooms = []
-    for (socketId in privateRoomUsers) {
-      if (privateRoomUsers[socketId].id === ReceiverId) {
-        receiverRooms.push(privateRoomUsers[socketId].currentRoom)
-      }
-    }
-    if (receiverRooms.length) {
-      console.log(detail('receiverRooms:'), receiverRooms)
-      return receiverRooms
-    }
-    return false
-  },
-  removeSocketFromList: (socket) => {
-    const userId = socketUsers[socket.id]
-    sockets.splice(sockets.indexOf(socket), 1)
-    delete socketUsers[socket.id]
-    if (!Object.keys(socketUsers).find((key) => socketUsers[key] === userId)) {
-      delete userData[userId]
-    }
-    return
-  },
-  removeUserFromPrivateRoom: (socketId) => {
-    delete privateRoomUsers[socketId]
-  },
-  removeUserFromPublicRoom: (socketId) => {
-    publicRoomUsers.splice(publicRoomUsers.indexOf(socketId), 1)
-  },
   toggleSeenMsgRecord: async (userId) => {
     //更新isSeen為true
     const MsgRecordOption = {
@@ -489,9 +428,12 @@ let socketService = {
     })
     return record
   },
-  seenTimeline: (socketId, timestamp) => {
-    userData[socketUsers[socketId]].timestamp = timestamp
-    return
+  seenTimeline: (userID, timestamp) => {
+    if (timestamp) {
+      userTimelineSeenAt[userID] = timestamp
+      return
+    }
+    userTimelineSeenAt[receiver] = new Date()
   },
   readTimeline: async (timelineId) => {
     return await TimelineRecord.update(
@@ -503,57 +445,52 @@ let socketService = {
       }
     )
   },
-  showNewUserOnline: (socketId) => {
-    console.log(
-      highlight(
-        ` User is online: ${userData[socketUsers[socketId]].name} / ${socketId}`
-      )
-    )
+  showUserOnline: (socket) => {
+    console.log(highlight(` User is online: ${socket.data.user.id} / ${socket.id}`))
+    console.log(notice('User Info (socket.data.user)\n'), socket.data.user)
   },
   showUserOffline: (socketId) => {
     console.log(highlight(`User is offline: ${socketId}`))
     return
   },
-  showJoinPublicRoomNotice: (userId, socketId) => {
-    console.log(notice(`join_public_room: ${userId}`))
-    console.log(notice(`加入公開的socket ID: ${socketId}`))
+  showJoinPublicRoomNotice: (socket) => {
+    console.log(notice(`[Join Public Room] userID: ${socket.data.user.id}`))
+    console.log(detail(`socket ID: ${socket.id}`))
+    console.log(detail('room result:'), Array.from(socket.rooms), '\n')
   },
-  showLeavePublicRoomNotice: (userId, socketId) => {
-    if (userId) {
-      console.log(notice(`leave_public_room: userID ${userId}`))
+  showJoinPrivatePageNotice: (socket, isAdded) => {
+    if (isAdded) {
+      console.log(notice(`[補 Join Private Page] userID: ${socket.data.user.id}`))
+      console.log(detail(`socket ID: ${socket.id}`))
       return
     }
-    console.log(
-      notice(
-        `leave_public_room: socketId|${socketId}  userID|${socketUsers[socketId]}`
-      )
-    )
+    console.log(notice(`[Join Private Page] userID: ${socket.data.user.id}`))
+    console.log(detail(`socket ID: ${socket.id}`))
+    console.log(detail('room result:'), Array.from(socket.rooms), '\n')
   },
-  showLeavePrivatePageNotice: (socketId) => {
-    console.log(
-      notice(`leave Private Page: userID ${socketUsers[socketId]}`)
-    )
+  showLeavePublicRoomNotice: (socket) => {
+    if (userId) {
+      console.log(notice(`[Leave Public Room] userID: ${socket.data.user.idd}`))
+      console.log(detail(`socket ID: ${socket.id}`))
+      console.log(detail('room result:'), Array.from(socket.rooms), '\n')
+      return
+    }
+    console.log(notice(`[Leave Public Room] userID|${socket.data.user.id}`))
+    console.log(detail(`socket ID: ${socket.id}`))
+    console.log(detail('room result:'), Array.from(socket.rooms), '\n')
   },
-  showGetPublicHistoryNotice: () => {
-    console.log(notice(`get_public_history: roomId ${1}`))
+  showAllSocketDetails: async (io) => {
+    const allIDs = Array.from(await io.allSockets())
+    console.log(detail('all sockets [系統偵測]'), '\n', allIDs)
+    const userData = {}
+    await allIDs.forEach(async (socketID) => userData[socketID] = await io.sockets.sockets.get(socketID).data.user)
+    console.log(detail('socket data'), '\n', userData)
+    const userRoom = {}
+    await allIDs.forEach(async (socketID) => userRoom[socketID] = Array.from(await io.sockets.sockets.get(socketID).rooms))
+    console.log(detail('socket rooms'), '\n', userRoom)
+    console.log(detail('user timestamps for timeline:'), '\n', userTimelineSeenAt)
   },
-  showPostPublicHistoryNotice: (content, userId) => {
-    console.log(notice(`post_public_msg:`, { content, userId }))
-  },
-  showAllSocketDetails: (ids) => {
-    console.log(
-      detail('all sockets [伺服器紀錄]'),
-      '\n',
-      sockets.map((item) => item.id)
-    )
-    console.log(detail('all sockets [系統偵測]'), '\n', Array.from(ids))
-    console.log(detail('all socketUsers [socketID-userID]'), '\n', socketUsers)
-    console.log(detail('all userData [詳細資料]'), '\n', userData)
-    console.log(detail('all publicRoomUsers '), '\n', publicRoomUsers)
-    console.log(detail('all privateRoomUsers '), '\n', privateRoomUsers)
-  },
-  createTimelineRecord: async (ReceiverId, PostId, type, currentUser) => {
-    const currentUserId = currentUser
+  createTimelineRecord: async (ReceiverId, PostId, type, currentUserId) => {
     if (type === 1) {
       const followOptions = {
         where: {
@@ -571,7 +508,7 @@ let socketService = {
       let data = await TimelineRecord.bulkCreate(subscribersData)
       data = data.map((item) => item.dataValues)
       return {
-        receiver: data.map((item) => item.UserId),
+        receiverId: data.map((item) => item.UserId),
         record
       }
     }
@@ -582,6 +519,7 @@ let socketService = {
       })
       record = record.toJSON()
       return {
+        receiverId: [ReceiverId],
         record: [record]
       }
     }
@@ -592,6 +530,7 @@ let socketService = {
       })
       record = record.toJSON()
       return {
+        receiverId: [ReceiverId],
         record: [record]
       }
     }
@@ -602,39 +541,22 @@ let socketService = {
       })
       record = record.toJSON()
       return {
+        receiverId: [ReceiverId],
         record: [record]
       }
     }
   },
-  checkReceiverOnTimelinePage: (socketIds) => {
-    const users = []
-    for (let socketId of socketIds) {
-      if (timelineUsers[socketId]) {
-        users.push(socketId)
-        return users
-      }
-    }
-    return false
-  },
-  sendTimeNotice: () => {
+  sendTimelineNotice: () => {
     return {
       message: 'new timeline_notice'
     }
   },
   updateTimelineSeenAt: (receiver) => {
-    userData[receiver].timelineSeenAt = new Date()
+    /* User table update timelineSeenAt */
   },
-  isUserOnline: (UserId) => {
-    for (let socketId in socketUsers) {
-      if (socketUsers[socketId] === UserId) {
-        return true
-      }
-    }
-    return false
-  },
-  atLeastOneUserOnline: function (receivers) {
-    for (let receiver of receivers) {
-      if (this.isUserOnline(receiver)) {
+  atLeastOneUserOnline: async function (receivers, io) {
+    for (const receiver of receivers) {
+      if (await io.in('User' + receiver).allSockets().size) {
         return true
       }
     }

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -46,7 +46,7 @@ module.exports = (server) => {
     })
     /* get public history */
     socket.on('get_public_history', async ({ offset, limit }, cb) => {
-      console.log(notice('[ON EVENT] get_public_history\n', { offset, limit }))
+      console.log(notice('[ON EVENT] get_public_history\n'), { offset, limit })
       const messages = await socketService.getRoomHistory(offset, limit, 1) //roomId 1 is PublicRoom
       cb(messages)
     })

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -3,56 +3,71 @@ const { authenticatedSocket } = require('../middleware/auth')
 const socketController = require('../controllers/socket/socketController')
 const socketService = require('../service/socketService')
 const chalk = require('chalk')
-const notice = chalk.cyanBright.underline.italic
+const notice = chalk.keyword('aqua').underline
 module.exports = (server) => {
   const io = socketio(server, {
     cors: {
-      origin: ['http://localhost:8080', 'https://ryanhsun.github.io'],
+      origin: ['http://localhost:8081', 'https://ryanhsun.github.io'],
       credentials: true
     },
     allowEIO3: true
   })
   io.use(authenticatedSocket).on('connection', async (socket) => {
     /* connect */
-    socketController.postSocket(socket)
+    socketService.showUserOnline(socket)
+    socketService.addNewSocketUserTimelineSeenAt(socket)
+    await socketService.showAllSocketDetails(io)
+
+    /* ---------------- EMITS ---------------- */
+    socket.emit('message', `Your socket id is  ${socket.id}`)
+    /* Message Notice */
     const getMsgNotice = await socketService.getMsgNotice(null, socket)
     socket.emit('get_msg_notice', getMsgNotice)
-    console.log(notice(`get_msg_notice to ${socket.id}`))
+    console.log(notice(`[EMIT] get_msg_notice → ${socket.id}`))
+
+    /* ---------------- LISTENERS ---------------- */
     socket.on('sendMessage', (data) => console.log(data))
+
     /* disconnect */
     socket.on('disconnecting', () => {
-      socketController.deleteSocket(socket, io)
+      socketService.deleteAndUpdateTimelineSeenAt(socket, io)
+      socketService.showUserOffline(socket.id)
     })
 
     /* join public room */
     socket.on('join_public_room', async ({ userId }) => {
-      socketController.joinPublicRoom(userId, socket, io)
+      console.log(notice('[ON EVENT] join_public_room'))
+      socketController.joinPublicRoom(socket, io)
     })
     /* leave public room */
     socket.on('leave_public_room', ({ userId }) => {
-      console.log(notice('伺服器收到事件 leave_public_room'))
-      socketController.leavePublicRoom(userId, socket, io)
+      console.log(notice('[ON EVENT] leave_public_room'))
+      socketController.leavePublicRoom(socket, io)
     })
     /* get public history */
     socket.on('get_public_history', async ({ offset, limit }, cb) => {
-      console.log(notice('伺服器收到事件 get_public_history'))
-      const messages = await socketController.getPublicHistory(offset, limit)
+      console.log(notice('[ON EVENT] get_public_history\n', { offset, limit }))
+      const messages = await socketService.getRoomHistory(offset, limit, 1) //roomId 1 is PublicRoom
       cb(messages)
     })
     /* public message (get and send) */
     socket.on('post_public_msg', ({ content, userId }) => {
-      socketController.postPublicMsg(content, userId, socket)
+      console.log(notice('[ON EVENT] post_public_msg', { content, userId }))
+      socketController.postPublicMsg(content, socket)
     })
     /* join private page */
     socket.on('join_private_page', async ({ userId }) => {
-      socketController.joinPrivatePage(userId, socket)
+      console.log(notice('[ON EVENT] join_private_page'))
+      socketController.joinPrivatePage(socket, io, false)
     })
     /* leave private page */
     socket.on('leave_private_page', () => {
-      socketController.leavePrivatePage(socket)
+      console.log(notice('[ON EVENT] leave_private_page'))
+      socketController.leavePrivatePage(socket, io)
     })
     /* join private room */
     socket.on('join_private_room', async ({ User1Id, User2Id }) => {
+      console.log(notice('[ON EVENT] join_private_room'), { User1Id, User2Id })
       const RoomId = await socketController.joinPrivateRoom(
         User1Id,
         User2Id,
@@ -61,53 +76,43 @@ module.exports = (server) => {
       )
       //return roomId to client
       socket.emit('join_private_room', RoomId)
-      console.log('emit join_private_room to user', RoomId)
+      console.log(notice(`[EMIT] join_private_room RoomId: ${RoomId} → ${socket.id}`))
     })
 
     /* get private history */
     socket.on('get_private_history', async ({ offset, limit, RoomId }, cb) => {
-      console.log(notice('伺服器收到事件 get_private_history'))
-      const messages = await socketController.getPrivateHistory(
-        offset,
-        limit,
-        RoomId
-      )
+      console.log(notice('[ON EVENT] get_private_history\n'), { offset, limit, RoomId })
+      const messages = await socketService.getRoomHistory(offset, limit, RoomId)
       cb(messages)
     })
     /* private message (get and send) */
-    socket.on(
-      'post_private_msg',
-      async ({ SenderId, ReceiverId, RoomId, content }) => {
-        socketController.postPrivateMsg(
-          SenderId,
-          ReceiverId,
-          RoomId,
-          content,
-          socket
-        )
-      }
-    )
+    socket.on('post_private_msg', async ({ SenderId, ReceiverId, RoomId, content }) => {
+      console.log(notice('[ON EVENT] post_private_msg\n'), { SenderId, ReceiverId, RoomId, content })
+      socketController.postPrivateMsg(SenderId, ReceiverId, RoomId, content, socket, io)
+    })
     /* timeline */
     socket.on('get_timeline_notice_details', async ({ offset, limit }, cb) => {
-      console.log(notice('伺服器收到事件 get_timeline_notice_details'))
-      const results = await socketService.getTimelineNoticeDetails(offset, limit, socket.id)
+      console.log(notice('[ON EVENT] get_timeline_notice_details'))
+      const results = await socketService.getTimelineNoticeDetails(offset, limit, socket)
       cb(results)
     })
     socket.on('seen_timeline', ({ timestamp }) => {
-      console.log(notice('伺服器收到事件 seen_timeline'))
-      socketService.seenTimeline(socket.id, timestamp)
+      console.log(notice('[ON EVENT] seen_timeline'))
+      socketService.seenTimeline(socket.data.user.id, timestamp)
     })
     socket.on('read_timeline', async ({ timelineId }) => {
-      console.log(notice('伺服器收到事件 read_timeline'))
+      console.log(notice('[ON EVENT] read_timeline'))
       await socketService.readTimeline(timelineId)
     })
     /* notification  */
     socket.on('post_timeline', async ({ ReceiverId, type, PostId }) => {
+      console.log(notice('[ON EVENT] post_timeline'))
       await socketController.postTimeline(
         ReceiverId,
         type,
         PostId,
-        socket
+        socket,
+        io
       )
     })
   })

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -90,6 +90,12 @@ module.exports = (server) => {
       console.log(notice('[ON EVENT] post_private_msg\n'), { SenderId, ReceiverId, RoomId, content })
       socketController.postPrivateMsg(SenderId, ReceiverId, RoomId, content, socket, io)
     })
+    /* get private rooms */
+    socket.on('get_private_rooms', async ({ offset, limit }, cb) => {
+      console.log(notice('[ON EVENT] get_private_rooms\n'), { offset, limit })
+      const rooms = await socketService.getPrivateRooms(socket.data.user.id, offset, limit)
+      cb(rooms)
+    })
     /* timeline */
     socket.on('get_timeline_notice_details', async ({ offset, limit }, cb) => {
       console.log(notice('[ON EVENT] get_timeline_notice_details'))

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -60,11 +60,12 @@ module.exports = (server) => {
       console.log(notice('[ON EVENT] leave_private_page'))
       socketController.leavePrivatePage(socket, io)
     })
-    socket.on('join_private_room', async ({ User1Id, User2Id }) => {
+    socket.on('join_private_room', async ({ User1Id, User2Id, RoomId }) => {
       console.log(notice('[ON EVENT] join_private_room'), { User1Id, User2Id })
       const RoomId = await socketController.joinPrivateRoom(
         User1Id,
         User2Id,
+        RoomId,
         socket,
         io
       )

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -7,7 +7,11 @@ const notice = chalk.keyword('aqua').underline
 module.exports = (server) => {
   const io = socketio(server, {
     cors: {
-      origin: ['http://localhost:8080', 'http://localhost:8081', 'https://ryanhsun.github.io'],
+      origin: [
+        'http://localhost:8080',
+        'http://localhost:8081',
+        'https://ryanhsun.github.io'
+      ],
       credentials: true
     },
     allowEIO3: true
@@ -60,30 +64,56 @@ module.exports = (server) => {
       console.log(notice('[ON EVENT] leave_private_page'))
       socketController.leavePrivatePage(socket, io)
     })
-    socket.on('join_private_room', async ({ User1Id, User2Id }) => {
+    socket.on('join_private_room', async ({ User1Id, User2Id, RoomId }) => {
       console.log(notice('[ON EVENT] join_private_room'), { User1Id, User2Id })
-      const RoomId = await socketController.joinPrivateRoom(
+      RoomId = await socketController.joinPrivateRoom(
         User1Id,
         User2Id,
+        RoomId,
         socket,
         io
       )
       //return roomId to client
       socket.emit('join_private_room', RoomId)
-      console.log(notice(`[EMIT] join_private_room RoomId: ${RoomId} → ${socket.id}`))
+      console.log(
+        notice(`[EMIT] join_private_room RoomId: ${RoomId} → ${socket.id}`)
+      )
     })
     socket.on('get_private_history', async ({ offset, limit, RoomId }, cb) => {
-      console.log(notice('[ON EVENT] get_private_history\n'), { offset, limit, RoomId })
+      console.log(notice('[ON EVENT] get_private_history\n'), {
+        offset,
+        limit,
+        RoomId
+      })
       const messages = await socketService.getRoomHistory(offset, limit, RoomId)
       cb(messages)
     })
-    socket.on('post_private_msg', async ({ SenderId, ReceiverId, RoomId, content }) => {
-      console.log(notice('[ON EVENT] post_private_msg\n'), { SenderId, ReceiverId, RoomId, content })
-      socketController.postPrivateMsg(SenderId, ReceiverId, RoomId, content, socket, io)
-    })
+    socket.on(
+      'post_private_msg',
+      async ({ SenderId, ReceiverId, RoomId, content }) => {
+        console.log(notice('[ON EVENT] post_private_msg\n'), {
+          SenderId,
+          ReceiverId,
+          RoomId,
+          content
+        })
+        socketController.postPrivateMsg(
+          SenderId,
+          ReceiverId,
+          RoomId,
+          content,
+          socket,
+          io
+        )
+      }
+    )
     socket.on('get_private_rooms', async ({ offset, limit }, cb) => {
       console.log(notice('[ON EVENT] get_private_rooms\n'), { offset, limit })
-      const rooms = await socketService.getPrivateRooms(socket.data.user.id, offset, limit)
+      const rooms = await socketService.getPrivateRooms(
+        socket.data.user.id,
+        offset,
+        limit
+      )
       cb(rooms)
     })
     /* ---------------- TIMELINE ---------------- */
@@ -92,17 +122,27 @@ module.exports = (server) => {
       socketService.seenTimeline(socket.data.user.id, timestamp)
       /* logs */
       console.log(notice('[ON EVENT] join_timeline_page'))
-      console.log(detail(`${socket.id}room result:\n`), Array.from(socket.rooms))
+      console.log(
+        detail(`${socket.id}room result:\n`),
+        Array.from(socket.rooms)
+      )
     })
     socket.on('leave_timeline_page', () => {
       socket.leave('TimelinePage')
       /* logs */
       console.log(notice('[ON EVENT] leave_timeline_page'))
-      console.log(detail(`${socket.id}room result:\n`), Array.from(socket.rooms))
+      console.log(
+        detail(`${socket.id}room result:\n`),
+        Array.from(socket.rooms)
+      )
     })
     socket.on('get_timeline_notice_details', async ({ offset, limit }, cb) => {
       console.log(notice('[ON EVENT] get_timeline_notice_details'))
-      const results = await socketService.getTimelineNoticeDetails(offset, limit, socket)
+      const results = await socketService.getTimelineNoticeDetails(
+        offset,
+        limit,
+        socket
+      )
       cb(results)
     })
     socket.on('read_timeline', async ({ timelineId }) => {
@@ -111,7 +151,7 @@ module.exports = (server) => {
     })
     socket.on('post_timeline', async ({ ReceiverId, type, PostId }) => {
       console.log(notice('[ON EVENT] post_timeline'))
-      await socketController.postTimeline( ReceiverId, type, PostId, socket, io )
+      await socketController.postTimeline(ReceiverId, type, PostId, socket, io)
     })
   })
 }

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -7,7 +7,7 @@ const notice = chalk.keyword('aqua').underline
 module.exports = (server) => {
   const io = socketio(server, {
     cors: {
-      origin: ['http://localhost:8081', 'https://ryanhsun.github.io'],
+      origin: ['http://localhost:8080', 'http://localhost:8081', 'https://ryanhsun.github.io'],
       credentials: true
     },
     allowEIO3: true


### PR DESCRIPTION
使用socket.io內建的`join()`、`leave()`、`allSockets()`等內建功能，替代原先手動紀錄上線使用者資訊的陣列與物件: `sockets`, `socketUsers`, `userData`, `publicRoomUsers`, `privateRoomUsers`, `timelineUsers`。

**說明：**
1. `socketUsers {Object}`以及`userData {Object}`的替代：
將使用者資料於連線時，以`socket.data.user`的形式存入socket中，讓**socket從此自帶使用者基本資料**。
2. `publicRoomUsers [Array]`以及`timelineUsers [Array]` 的替代：
利用`'PublicRoom'`以及`'TimelinePage'`房間來管理停留在公開聊天室或動態頁面的使用者，搭配`join_public_room`、`leave_public_room`等事件來掌握使用者行蹤。
3. `privateRoomUsers {Object}`的替代：
利用`'PrivatePage'`房間來管理停留在私訊頁面的使用者，並且在開啟/離開聊天室時將使用者 `join`/`leave`名稱為`RoomId`的房間，來掌握使用者正在跟誰聊天。

**新增設計：**
讓使用者於連線時就加入名為`UserX`的房間，其中X為該使用者的id。
_例如：id為1的使用者，無論開了幾個socket連線，所有socket都會被加入名為User1的房間。_
如此做資料傳送時，方便同步傳送給同位使用者的所有socket。